### PR TITLE
feat: integrate `InteractionManager` in stack

### DIFF
--- a/packages/stack/src/views/Stack/Card.tsx
+++ b/packages/stack/src/views/Stack/Card.tsx
@@ -7,6 +7,7 @@ import {
   StyleProp,
   ViewStyle,
   Platform,
+  InteractionManager,
 } from 'react-native';
 import Animated from 'react-native-reanimated';
 import {
@@ -342,7 +343,13 @@ export default class Card extends React.Component<Props> {
     finished: new Value(FALSE),
   };
 
+  private interactionHandle: number | null = null;
+
   private handleTransitionEnd = () => {
+    if (this.interactionHandle !== null) {
+      InteractionManager.clearInteractionHandle(this.interactionHandle);
+    }
+
     this.isRunningAnimation = false;
     this.interpolatedStyle = this.getInterpolatedStyle(
       this.props.styleInterpolator,
@@ -380,6 +387,8 @@ export default class Card extends React.Component<Props> {
         set(this.isVisible, isVisible),
         startClock(this.clock),
         call([this.isVisible], ([value]: ReadonlyArray<Binary>) => {
+          this.interactionHandle = InteractionManager.createInteractionHandle();
+
           const { onTransitionStart } = this.props;
           this.noAnimationStartedSoFar = false;
           this.isRunningAnimation = true;

--- a/packages/stack/src/views/Stack/Card.tsx
+++ b/packages/stack/src/views/Stack/Card.tsx
@@ -263,6 +263,10 @@ export default class Card extends React.Component<Props> {
   }
 
   componentWillUnmount(): void {
+    if (this.interactionHandle !== null) {
+      InteractionManager.clearInteractionHandle(this.interactionHandle);
+    }
+
     // It might sometimes happen than animation will be unmounted
     // during running. However, we need to invoke listener onClose
     // manually in this case


### PR DESCRIPTION
In RN Animated `InteractionManager` is integrated automatically when starting animations but this is not the case in reanimated. This integrates it for stack.