### PR TITLE
fix: don't fade incoming background when fading header

### DIFF
--- a/packages/stack/src/TransitionConfigs/HeaderStyleInterpolators.tsx
+++ b/packages/stack/src/TransitionConfigs/HeaderStyleInterpolators.tsx
@@ -101,8 +101,8 @@ export function forFade({
 }: StackHeaderInterpolationProps): StackHeaderInterpolatedStyle {
   const progress = add(current.progress, next ? next.progress : 0);
   const opacity = interpolate(progress, {
-    inputRange: [0, 1, 2],
-    outputRange: [0, 1, 0],
+    inputRange: [0, 1, 1.9999, 2],
+    outputRange: [0, 1, 1, 0],
   });
 
   return {

--- a/packages/stack/src/TransitionConfigs/HeaderStyleInterpolators.tsx
+++ b/packages/stack/src/TransitionConfigs/HeaderStyleInterpolators.tsx
@@ -101,15 +101,15 @@ export function forFade({
 }: StackHeaderInterpolationProps): StackHeaderInterpolatedStyle {
   const progress = add(current.progress, next ? next.progress : 0);
   const opacity = interpolate(progress, {
-    inputRange: [0, 1, 1.9999, 2],
-    outputRange: [0, 1, 1, 0],
+    inputRange: [0, 1, 2],
+    outputRange: [0, 1, 0],
   });
 
   return {
     leftButtonStyle: { opacity },
     rightButtonStyle: { opacity },
     titleStyle: { opacity },
-    backgroundStyle: { opacity },
+    backgroundStyle: { opacity: current.progress },
   };
 }
 


### PR DESCRIPTION
During a cross-fade, the header on the back should still have `opacity=1` to prevent the header become translucent and avoid anything in the back showing up.

The problem with the current animation is that opacities of layers are multiplied instead of added. Two white view with `opacity=0.5` on top of each other isn't equivalent to one white view with `opacity=1`.

![opacity](https://user-images.githubusercontent.com/648142/66907160-cc506d80-f000-11e9-8bb4-36bec8b90261.png)
