### PR TITLE
feat: support transform style for header

### DIFF
--- a/packages/stack/src/types.tsx
+++ b/packages/stack/src/types.tsx
@@ -185,7 +185,9 @@ export type StackHeaderOptions = {
    * This is useful for using backgrounds such as an image or a gradient.
    * You can use this with `headerTransparent` to render a blur view, for example, to create a translucent header.
    */
-  headerBackground?: () => React.ReactNode;
+  headerBackground?: (props: {
+    style: StyleProp<ViewStyle>;
+  }) => React.ReactNode;
   /**
    * Style object for the header. You can specify a custom background color here, for example.
    */

--- a/packages/stack/src/views/Header/HeaderSegment.tsx
+++ b/packages/stack/src/views/Header/HeaderSegment.tsx
@@ -303,7 +303,7 @@ export default class HeaderSegment extends React.Component<Props, State> {
           style={[StyleSheet.absoluteFill, backgroundStyle]}
         >
           {headerBackground ? (
-            headerBackground()
+            headerBackground({ style: safeStyles })
           ) : headerTransparent ? null : (
             <HeaderBackground style={safeStyles} />
           )}

--- a/packages/stack/src/views/Header/HeaderSegment.tsx
+++ b/packages/stack/src/views/Header/HeaderSegment.tsx
@@ -222,6 +222,7 @@ export default class HeaderSegment extends React.Component<Props, State> {
       shadowOpacity,
       shadowRadius,
       opacity,
+      transform,
       ...unsafeStyles
     } = StyleSheet.flatten(customHeaderStyle || {}) as ViewStyle;
 
@@ -263,6 +264,7 @@ export default class HeaderSegment extends React.Component<Props, State> {
       shadowOpacity,
       shadowRadius,
       opacity,
+      transform,
     };
 
     // Setting a property to undefined triggers default style
@@ -308,7 +310,7 @@ export default class HeaderSegment extends React.Component<Props, State> {
         </Animated.View>
         <Animated.View
           pointerEvents="box-none"
-          style={[{ height, minHeight, maxHeight, opacity }]}
+          style={[{ height, minHeight, maxHeight, opacity, transform }]}
         >
           <View pointerEvents="none" style={{ height: insets.top }} />
           <View pointerEvents="box-none" style={styles.content}>


### PR DESCRIPTION
Two related things in this PR:

- add `transform` in the `safeStyles` headerStyle
- add the `safeStyles` headerStyle as argument in the `headerBackground` function

Use case: **Create a collapsible scrollview header**. To migrate this use case from 4 to 5 this PR is needed but the philosophy isn't far from previous react-navigation. You need to set `headerTransparent` to `true` and use a custom `headerBackground` (even if don't really want a custom one).

It's needed to transform the `headerBackground` and the View that wrap the headerLeft/Right and the headerTitle.
Also, giving `headerStyle` as argument to `headerBackground` function make it easier to customize by setting an `headerStyle` option in a screen instead of recreate an entire `headerBackground` for each screen.