### PR TITLE
fix: fix default BottomTabBar button

### DIFF
--- a/packages/bottom-tabs/src/views/BottomTabBar.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabBar.tsx
@@ -265,9 +265,7 @@ export default class TabBarBottom extends React.Component<Props, State> {
       getAccessibilityLabel,
       getAccessibilityRole,
       getAccessibilityStates,
-      renderButton = (props: BottomTabBarButtonProps) => (
-        <TouchableWithoutFeedbackWrapper {...props} />
-      ),
+      renderButton,
       getTestID,
       style,
       tabStyle,

--- a/packages/bottom-tabs/src/views/BottomTabBar.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabBar.tsx
@@ -13,7 +13,6 @@ import { Route, NavigationContext } from '@react-navigation/core';
 import { SafeAreaConsumer } from 'react-native-safe-area-context';
 
 import TabBarIcon from './TabBarIcon';
-import TouchableWithoutFeedbackWrapper from './TouchableWithoutFeedbackWrapper';
 import { BottomTabBarProps, BottomTabBarButtonProps } from '../types';
 
 type State = {

--- a/packages/bottom-tabs/src/views/BottomTabView.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabView.tsx
@@ -4,14 +4,15 @@ import {
   StyleSheet,
   AccessibilityRole,
   AccessibilityStates,
-  TouchableWithoutFeedbackWrapper,
 } from 'react-native';
+
 import { Route, CommonActions } from '@react-navigation/core';
 import { TabNavigationState } from '@react-navigation/routers';
 // eslint-disable-next-line import/no-unresolved
 import { ScreenContainer } from 'react-native-screens';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 
+import TouchableWithoutFeedbackWrapper from './TouchableWithoutFeedbackWrapper';
 import ResourceSavingScene from './ResourceSavingScene';
 import BottomTabBar from './BottomTabBar';
 import {

--- a/packages/bottom-tabs/src/views/BottomTabView.tsx
+++ b/packages/bottom-tabs/src/views/BottomTabView.tsx
@@ -4,6 +4,7 @@ import {
   StyleSheet,
   AccessibilityRole,
   AccessibilityStates,
+  TouchableWithoutFeedbackWrapper,
 } from 'react-native';
 import { Route, CommonActions } from '@react-navigation/core';
 import { TabNavigationState } from '@react-navigation/routers';
@@ -63,7 +64,7 @@ export default class BottomTabView extends React.Component<Props, State> {
       return options.tabBarButton(rest);
     }
 
-    return undefined;
+    return <TouchableWithoutFeedbackWrapper {...rest} />;
   };
 
   private renderIcon = ({


### PR DESCRIPTION
Hey, 

I noticed that creating a new BottomTabNavigator required the TabBarButton to be specifically defined by the user, and then saw that the default fallback for renderbutton would never resolve as it is always a function (returning the user defined button, or undefined). This small fix moves the default fallback to the BottomTabView, so a user can use the default navigation tab bar button.