### PR TITLE
feat: support headerLeft for native-stack

### DIFF
--- a/packages/native-stack/src/types.tsx
+++ b/packages/native-stack/src/types.tsx
@@ -91,6 +91,10 @@ export type NativeStackNavigationOptions = {
    */
   headerLargeTitle?: boolean;
   /**
+   * Function which returns a React Element to display on the left side of the header.
+   */
+  headerLeft?: () => React.ReactNode;
+  /**
    * Function which returns a React Element to display on the right side of the header.
    */
   headerRight?: () => React.ReactNode;

--- a/packages/native-stack/src/views/HeaderConfig.tsx
+++ b/packages/native-stack/src/views/HeaderConfig.tsx
@@ -4,6 +4,8 @@ import {
   ScreenStackHeaderConfig,
   // @ts-ignore
   ScreenStackHeaderRightView,
+  // @ts-ignore
+  ScreenStackHeaderLeftView,
   // eslint-disable-next-line import/no-unresolved
 } from 'react-native-screens';
 import { Route } from '@react-navigation/core';
@@ -17,6 +19,7 @@ export default function HeaderConfig(props: Props) {
   const {
     route,
     title,
+    headerLeft,
     headerRight,
     headerTitle,
     headerBackTitle,
@@ -64,6 +67,9 @@ export default function HeaderConfig(props: Props) {
       largeTitleFontSize={headerLargeTitleStyle.fontSize}
       backgroundColor={headerStyle.backgroundColor}
     >
+      {headerLeft !== undefined ? (
+        <ScreenStackHeaderLeftView>{headerLeft()}</ScreenStackHeaderLeftView>
+      ) : null}
       {headerRight !== undefined ? (
         <ScreenStackHeaderRightView>{headerRight()}</ScreenStackHeaderRightView>
       ) : null}


### PR DESCRIPTION
Same thing as `headerRight`. This is useful to customize the back button to use `Cancel` text for example.