### PR TITLE
fix: use Partial type for initialParam

### DIFF
--- a/packages/core/src/types.tsx
+++ b/packages/core/src/types.tsx
@@ -533,7 +533,7 @@ export type RouteConfig<
   /**
    * Initial params object for the route.
    */
-  initialParams?: Partial<ParamList[RouteName]>
+  initialParams?: Partial<ParamList[RouteName]>;
 } & (
   | {
       /**

--- a/packages/core/src/types.tsx
+++ b/packages/core/src/types.tsx
@@ -533,7 +533,7 @@ export type RouteConfig<
   /**
    * Initial params object for the route.
    */
-  initialParams?: ParamList[RouteName];
+  initialParams?: Partial<ParamList[RouteName]>
 } & (
   | {
       /**


### PR DESCRIPTION
Based on this commit https://github.com/react-navigation/navigation-ex/commit/11efb066429a3fc8b7e8e48d897286208d9a5449

Does it make sense that you can set initialParams as a partial of the routeParams as they are now merged with the pushed screen?