### PR TITLE
fix: change transition spec ios for spring animation

### DIFF
--- a/packages/stack/src/TransitionConfigs/TransitionSpecs.tsx
+++ b/packages/stack/src/TransitionConfigs/TransitionSpecs.tsx
@@ -11,8 +11,8 @@ export const TransitionIOSSpec: TransitionSpec = {
     damping: 500,
     mass: 3,
     overshootClamping: true,
-    restDisplacementThreshold: 0.01,
-    restSpeedThreshold: 0.01,
+    restDisplacementThreshold: 40,
+    restSpeedThreshold: 100,
   },
 };
 


### PR DESCRIPTION
fix: change transition spec ios for spring animation so finish callback could be trigger smoothly
https://github.com/facebook/react-native/issues/20783#issuecomment-481372109

Current value make animated finished callback has ~300ms delayed, this effect
https://github.com/react-navigation/navigation-ex/blob/master/packages/stack/src/views/Stack/Card.tsx#L169