### PR TITLE
feat: Block pointer events if overlay is enabled

### DIFF
--- a/packages/stack/src/views/Stack/Card.tsx
+++ b/packages/stack/src/views/Stack/Card.tsx
@@ -463,7 +463,7 @@ export default class Card extends React.Component<Props> {
         ) : null}
         <Animated.View
           style={[styles.container, containerStyle, customContainerStyle]}
-          pointerEvents={ overlayEnabled ? 'auto' : 'box-none' }
+          pointerEvents={overlayEnabled ? 'auto' : 'box-none'}
         >
           <PanGestureHandler
             ref={this.gestureRef}

--- a/packages/stack/src/views/Stack/Card.tsx
+++ b/packages/stack/src/views/Stack/Card.tsx
@@ -463,7 +463,7 @@ export default class Card extends React.Component<Props> {
         ) : null}
         <Animated.View
           style={[styles.container, containerStyle, customContainerStyle]}
-          pointerEvents={ overlayEnabled ? 'auto' : 'box-none }
+          pointerEvents={ overlayEnabled ? 'auto' : 'box-none' }
         >
           <PanGestureHandler
             ref={this.gestureRef}

--- a/packages/stack/src/views/Stack/Card.tsx
+++ b/packages/stack/src/views/Stack/Card.tsx
@@ -463,7 +463,7 @@ export default class Card extends React.Component<Props> {
         ) : null}
         <Animated.View
           style={[styles.container, containerStyle, customContainerStyle]}
-          pointerEvents="box-none"
+          pointerEvents={ overlayEnabled ? 'auto' : 'box-none }
         >
           <PanGestureHandler
             ref={this.gestureRef}


### PR DESCRIPTION
This prevents pointer events from bleeding through the overlay which would result in background components being interactable when the overlay is active.

Great if you've created your own `TransitionPreset` with a custom `cardStyleInterpolator`.

![](https://user-images.githubusercontent.com/793406/72456994-0418ae00-37c6-11ea-98b2-c428999ce85b.gif)