### PR TITLE
feat: check for state type

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,9 @@
     ],
     "moduleNameMapper": {
       "@react-navigation/([^/]+)": "<rootDir>/packages/$1/src"
+    },
+    "globals": {
+      "__DEV__": true
     }
   },
   "prettier": {

--- a/packages/core/src/NavigationContainer.tsx
+++ b/packages/core/src/NavigationContainer.tsx
@@ -1,3 +1,5 @@
+/* global __DEV__ */
+
 import * as React from 'react';
 import * as CommonActions from './CommonActions';
 import EnsureSingleNavigator from './EnsureSingleNavigator';
@@ -242,6 +244,15 @@ const Container = React.forwardRef(function NavigationContainer(
   );
 
   React.useEffect(() => {
+    if (__DEV__) {
+      if (
+        typeof state !== 'undefined' &&
+        Object.prototype.toString.call(state) !== '[object Object]'
+      ) {
+        console.warn('Navigation state contains non-serialiable value');
+      }
+    }
+
     if (skipTrackingRef.current) {
       skipTrackingRef.current = false;
     } else {

--- a/packages/core/src/NavigationContainer.tsx
+++ b/packages/core/src/NavigationContainer.tsx
@@ -1,5 +1,3 @@
-/* global __DEV__ */
-
 import * as React from 'react';
 import * as CommonActions from './CommonActions';
 import EnsureSingleNavigator from './EnsureSingleNavigator';
@@ -244,6 +242,7 @@ const Container = React.forwardRef(function NavigationContainer(
   );
 
   React.useEffect(() => {
+    // eslint-disable-next-line no-undef
     if (__DEV__) {
       if (
         typeof state !== 'undefined' &&


### PR DESCRIPTION
Fulfills the task: `Add warning for non-serializable values in navigation state`

Navigation state is checked against undefined or object. In a case of different value, gives a warning. 

Note: 
needed to add`__DEV__` global to the `package.json` - tests failing otherwise.