### PR TITLE
refactor: split Overlay into a new component

### DIFF
--- a/packages/drawer/src/index.tsx
+++ b/packages/drawer/src/index.tsx
@@ -11,7 +11,6 @@ export { default as DrawerItem } from './views/DrawerItem';
 export { default as DrawerItemList } from './views/DrawerItemList';
 export { default as DrawerContent } from './views/DrawerContent';
 export { default as DrawerContentScrollView } from './views/DrawerContentScrollView';
-export { default as Overlay } from './views/Overlay';
 
 /**
  * Utilities

--- a/packages/drawer/src/index.tsx
+++ b/packages/drawer/src/index.tsx
@@ -11,6 +11,7 @@ export { default as DrawerItem } from './views/DrawerItem';
 export { default as DrawerItemList } from './views/DrawerItemList';
 export { default as DrawerContent } from './views/DrawerContent';
 export { default as DrawerContentScrollView } from './views/DrawerContentScrollView';
+export { default as Overlay } from './views/Overlay';
 
 /**
  * Utilities

--- a/packages/drawer/src/views/Drawer.tsx
+++ b/packages/drawer/src/views/Drawer.tsx
@@ -17,6 +17,7 @@ import {
   State,
 } from 'react-native-gesture-handler';
 import Animated from 'react-native-reanimated';
+import Overlay from './Overlay';
 
 const {
   Clock,
@@ -25,7 +26,6 @@ const {
   clockRunning,
   startClock,
   stopClock,
-  interpolate,
   spring,
   abs,
   add,
@@ -51,8 +51,6 @@ const TRUE = 1;
 const FALSE = 0;
 const NOOP = 0;
 const UNSET = -1;
-
-const PROGRESS_EPSILON = 0.05;
 
 const DIRECTION_LEFT = 1;
 const DIRECTION_RIGHT = -1;
@@ -577,26 +575,7 @@ export default class DrawerView extends React.PureComponent<Props> {
               {renderSceneContent({ progress: this.progress })}
             </View>
             <TapGestureHandler onHandlerStateChange={this.handleTapStateChange}>
-              <Animated.View
-                style={[
-                  styles.overlay,
-                  {
-                    opacity: interpolate(this.progress, {
-                      inputRange: [PROGRESS_EPSILON, 1],
-                      outputRange: [0, 1],
-                    }),
-                    // We don't want the user to be able to press through the overlay when drawer is open
-                    // One approach is to adjust the pointerEvents based on the progress
-                    // But we can also send the overlay behind the screen, which works, and is much less code
-                    zIndex: cond(
-                      greaterThan(this.progress, PROGRESS_EPSILON),
-                      0,
-                      -1
-                    ),
-                  },
-                  overlayStyle,
-                ]}
-              />
+              <Overlay progress={this.progress} style={overlayStyle} />
             </TapGestureHandler>
           </Animated.View>
           <Animated.Code
@@ -640,10 +619,6 @@ const styles = StyleSheet.create({
     bottom: 0,
     width: '80%',
     maxWidth: '100%',
-  },
-  overlay: {
-    ...StyleSheet.absoluteFillObject,
-    backgroundColor: 'rgba(0, 0, 0, 0.5)',
   },
   content: {
     flex: 1,

--- a/packages/drawer/src/views/Overlay.tsx
+++ b/packages/drawer/src/views/Overlay.tsx
@@ -1,0 +1,51 @@
+import * as React from 'react';
+import { Platform, StyleSheet } from 'react-native';
+import Animated from 'react-native-reanimated';
+
+const { interpolate, cond, greaterThan } = Animated;
+
+const PROGRESS_EPSILON = 0.05;
+
+type Props = React.ComponentProps<typeof Animated.View> & {
+  progress: Animated.Node<number>;
+};
+
+const Overlay = React.forwardRef(function Overlay(
+  { progress, style, ...props }: Props,
+  ref: React.Ref<Animated.View>
+) {
+  const animatedStyle = {
+    opacity: interpolate(progress, {
+      inputRange: [PROGRESS_EPSILON, 1],
+      outputRange: [0, 1],
+    }),
+    // We don't want the user to be able to press through the overlay when drawer is open
+    // One approach is to adjust the pointerEvents based on the progress
+    // But we can also send the overlay behind the screen, which works, and is much less code
+    zIndex: cond(greaterThan(progress, PROGRESS_EPSILON), 0, -1),
+  };
+
+  return (
+    <Animated.View
+      {...props}
+      ref={ref}
+      style={[styles.overlay, animatedStyle, style]}
+    />
+  );
+});
+
+const styles = StyleSheet.create({
+  overlay: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    ...Platform.select({
+      web: {
+        // Disable touch highlight on mobile Safari.
+        WebkitTapHighlightColor: 'transparent',
+      },
+      default: {},
+    }),
+  },
+});
+
+export default Overlay;


### PR DESCRIPTION
- Disable touch highlight on mobile Safari