### PR TITLE
feat: add parsing empty path string

### DIFF
--- a/packages/core/src/__tests__/getPathFromState.test.tsx
+++ b/packages/core/src/__tests__/getPathFromState.test.tsx
@@ -292,7 +292,7 @@ it('handles nested object with stringify in it', () => {
   };
 
   expect(getPathFromState(state, config)).toBe(path);
-  expect(getPathFromState(getStateFromPath(path))).toBe(path);
+  expect(getPathFromState(getStateFromPath(path, config), config)).toBe(path);
 });
 
 it('handles nested object for second route depth', () => {
@@ -326,7 +326,7 @@ it('handles nested object for second route depth', () => {
   };
 
   expect(getPathFromState(state, config)).toBe(path);
-  expect(getPathFromState(getStateFromPath(path))).toBe(path);
+  expect(getPathFromState(getStateFromPath(path), config)).toBe(path);
 });
 
 it('handles nested object for second route depth and and path and stringify in roots', () => {
@@ -372,3 +372,82 @@ it('handles nested object for second route depth and and path and stringify in r
   expect(getPathFromState(state, config)).toBe(path);
   expect(getPathFromState(getStateFromPath(path))).toBe(path);
 });
+
+it('converts state with initial prop in config to empty path string', () => {
+  const state = {
+    routes: [
+      {
+        name: 'Foo',
+      },
+    ],
+  };
+
+  const config = {
+    Foo: {
+      path: 'foo/:id',
+      stringify: {
+        id: (id: number) => `id=${id}`,
+      },
+      initial: true,
+      Foe: 'foe',
+      Bar: {
+        path: 'bar/:id',
+        stringify: {
+          id: (id: number) => `id=${id}`,
+        },
+        parse: {
+          id: Number,
+        },
+        Baz: 'baz',
+      },
+    },
+  };
+
+  const path = '';
+
+  expect(getPathFromState(state, config)).toBe(path);
+  expect(getPathFromState(getStateFromPath(path, config), config)).toBe(path);
+});
+
+// it('converts state with initial prop in nested config to empty path string', () => {
+//   const state = {
+//     routes: [
+//       {
+//         name: 'Foo',
+//         state: {
+//           routes: [
+//             {
+//               name: 'Bar',
+//             },
+//           ],
+//         },
+//       },
+//     ],
+//   };
+
+//   const config = {
+//     Foo: {
+//       path: 'foo/:id',
+//       stringify: {
+//         id: (id: number) => `id=${id}`,
+//       },
+//       Foe: 'foe',
+//       Bar: {
+//         path: 'bar/:id',
+//         stringify: {
+//           id: (id: number) => `id=${id}`,
+//         },
+//         parse: {
+//           id: Number,
+//         },
+//         initial: true,
+//         Baz: 'baz',
+//       },
+//     },
+//   };
+
+//   const path = '';
+
+//   expect(getPathFromState(state, config)).toBe(path);
+//   expect(getPathFromState(getStateFromPath(path, config))).toBe(path);
+// });

--- a/packages/core/src/__tests__/getPathFromState.test.tsx
+++ b/packages/core/src/__tests__/getPathFromState.test.tsx
@@ -36,7 +36,7 @@ it('converts state to path string', () => {
 
 it('converts state to path string with config', () => {
   const path = '/few/bar/sweet/apple/baz/jane?id=x10&valid=true';
-  const stateConfig = {
+  const config = {
     Foo: 'few',
     Bar: 'bar/:type/:fruit',
     Baz: {
@@ -46,14 +46,6 @@ it('converts state to path string with config', () => {
         id: (id: string) => Number(id.replace(/^x/, '')),
         valid: Boolean,
       },
-    },
-  };
-
-  const pathConfig = {
-    Foo: 'few',
-    Bar: 'bar/:type/:fruit',
-    Baz: {
-      path: 'baz/:author',
       stringify: {
         author: (author: string) => author.toLowerCase(),
         id: (id: number) => `x${id}`,
@@ -87,10 +79,8 @@ it('converts state to path string with config', () => {
     ],
   };
 
-  expect(getPathFromState(state, pathConfig)).toBe(path);
-  expect(
-    getPathFromState(getStateFromPath(path, stateConfig), pathConfig)
-  ).toBe(path);
+  expect(getPathFromState(state, config)).toBe(path);
+  expect(getPathFromState(getStateFromPath(path, config), config)).toBe(path);
 });
 
 it('handles route without param', () => {
@@ -127,7 +117,7 @@ it("doesn't add query param for empty params", () => {
 
 it('handles state with config with nested screens', () => {
   const path = '/few/bar/sweet/apple/baz/jane?answer=42&count=10&valid=true';
-  const stateConfig = {
+  const config = {
     Foo: {
       Foe: 'few',
     },
@@ -139,16 +129,6 @@ it('handles state with config with nested screens', () => {
         count: Number,
         valid: Boolean,
       },
-    },
-  };
-
-  const pathConfig = {
-    Foo: {
-      Foe: 'few',
-    },
-    Bar: 'bar/:type/:fruit',
-    Baz: {
-      path: 'baz/:author',
       stringify: {
         author: (author: string) => author.toLowerCase(),
         id: (id: number) => `x${id}`,
@@ -193,15 +173,13 @@ it('handles state with config with nested screens', () => {
     ],
   };
 
-  expect(getPathFromState(state, pathConfig)).toBe(path);
-  expect(
-    getPathFromState(getStateFromPath(path, stateConfig), pathConfig)
-  ).toBe(path);
+  expect(getPathFromState(state, config)).toBe(path);
+  expect(getPathFromState(getStateFromPath(path, config), config)).toBe(path);
 });
 
 it('handles state with config with nested screens and unused configs', () => {
   const path = '/few/baz/jane?answer=42&count=10&valid=true';
-  const stateConfig = {
+  const config = {
     Foo: {
       Foe: 'few',
     },
@@ -212,15 +190,6 @@ it('handles state with config with nested screens and unused configs', () => {
         count: Number,
         valid: Boolean,
       },
-    },
-  };
-
-  const pathConfig = {
-    Foo: {
-      Foe: 'few',
-    },
-    Baz: {
-      path: 'baz/:author',
       stringify: {
         author: (author: string) => author.replace(/^\w/, c => c.toLowerCase()),
         unknown: (_: unknown) => 'x',
@@ -256,28 +225,13 @@ it('handles state with config with nested screens and unused configs', () => {
     ],
   };
 
-  expect(getPathFromState(state, pathConfig)).toBe(path);
-  expect(
-    getPathFromState(getStateFromPath(path, stateConfig), pathConfig)
-  ).toBe(path);
+  expect(getPathFromState(state, config)).toBe(path);
+  expect(getPathFromState(getStateFromPath(path, config), config)).toBe(path);
 });
 
 it('handles nested object with stringify in it', () => {
   const path = '/bar/sweet/apple/few/bis/jane?answer=42&count=10&valid=true';
-  const stateConfig = {
-    Foo: {
-      Foe: 'few',
-    },
-    Bar: 'bar/:type/:fruit',
-    Baz: {
-      Bos: 'bos',
-      Bis: {
-        path: 'bis/:author',
-      },
-    },
-  };
-
-  const pathConfig = {
+  const config = {
     Foo: {
       Foe: 'few',
     },
@@ -337,10 +291,8 @@ it('handles nested object with stringify in it', () => {
     ],
   };
 
-  expect(getPathFromState(state, pathConfig)).toBe(path);
-  expect(
-    getPathFromState(getStateFromPath(path, stateConfig), pathConfig)
-  ).toBe(path);
+  expect(getPathFromState(state, config)).toBe(path);
+  expect(getPathFromState(getStateFromPath(path, config), config)).toBe(path);
 });
 
 it('handles nested object for second route depth', () => {
@@ -379,7 +331,7 @@ it('handles nested object for second route depth', () => {
 
 it('handles nested object for second route depth and and path and stringify in roots', () => {
   const path = '/baz';
-  const stateConfig = {
+  const config = {
     Foo: {
       path: 'foo/:id',
       Foe: 'foe',
@@ -388,20 +340,6 @@ it('handles nested object for second route depth and and path and stringify in r
         parse: {
           id: Number,
         },
-        Baz: 'baz',
-      },
-    },
-  };
-
-  const pathConfig = {
-    Foo: {
-      path: 'foo/:id',
-      stringify: {
-        id: (id: number) => `id=${id}`,
-      },
-      Foe: 'foe',
-      Bar: {
-        path: 'bar/:id',
         stringify: {
           id: (id: number) => `id=${id}`,
         },
@@ -428,10 +366,8 @@ it('handles nested object for second route depth and and path and stringify in r
     ],
   };
 
-  expect(getPathFromState(state, pathConfig)).toBe(path);
-  expect(
-    getPathFromState(getStateFromPath(path, stateConfig), pathConfig)
-  ).toBe(path);
+  expect(getPathFromState(state, config)).toBe(path);
+  expect(getPathFromState(getStateFromPath(path, config), config)).toBe(path);
 });
 
 it('converts state with initial prop in config to empty path string', () => {
@@ -443,7 +379,7 @@ it('converts state with initial prop in config to empty path string', () => {
     ],
   };
 
-  const stateConfig = {
+  const config = {
     Foo: {
       path: 'foo/:id',
       stringify: {
@@ -456,26 +392,8 @@ it('converts state with initial prop in config to empty path string', () => {
         parse: {
           id: Number,
         },
-        Baz: 'baz',
-      },
-    },
-  };
-
-  const pathConfig = {
-    Foo: {
-      path: 'foo/:id',
-      stringify: {
-        id: (id: number) => `id=${id}`,
-      },
-      initial: true,
-      Foe: 'foe',
-      Bar: {
-        path: 'bar/:id',
         stringify: {
           id: (id: number) => `id=${id}`,
-        },
-        parse: {
-          id: Number,
         },
         Baz: 'baz',
       },
@@ -484,10 +402,8 @@ it('converts state with initial prop in config to empty path string', () => {
 
   const path = '';
 
-  expect(getPathFromState(state, pathConfig)).toBe(path);
-  expect(
-    getPathFromState(getStateFromPath(path, stateConfig), pathConfig)
-  ).toBe(path);
+  expect(getPathFromState(state, config)).toBe(path);
+  expect(getPathFromState(getStateFromPath(path, config), config)).toBe(path);
 });
 
 it('converts state with initial prop in nested config to an empty path string', () => {
@@ -509,7 +425,7 @@ it('converts state with initial prop in nested config to an empty path string', 
     ],
   };
 
-  const stateConfig = {
+  const config = {
     Foo: {
       path: 'foo/:id',
       Foe: 'foe',
@@ -518,22 +434,6 @@ it('converts state with initial prop in nested config to an empty path string', 
         parse: {
           id: Number,
         },
-        Baz: {
-          initial: true,
-        },
-      },
-    },
-  };
-
-  const pathConfig = {
-    Foo: {
-      path: 'foo/:id',
-      stringify: {
-        id: (id: number) => `id=${id}`,
-      },
-      Foe: 'foe',
-      Bar: {
-        path: 'bar/:id',
         stringify: {
           id: (id: number) => `id=${id}`,
         },
@@ -546,10 +446,8 @@ it('converts state with initial prop in nested config to an empty path string', 
 
   const path = '';
 
-  expect(getPathFromState(state, pathConfig)).toBe(path);
-  expect(
-    getPathFromState(getStateFromPath(path, stateConfig), pathConfig)
-  ).toBe(path);
+  expect(getPathFromState(state, config)).toBe(path);
+  expect(getPathFromState(getStateFromPath(path, config), config)).toBe(path);
 });
 
 it('throws if state is undefined', () => {
@@ -583,4 +481,49 @@ it('throws if state is undefined', () => {
   expect(() =>
     getPathFromState(getStateFromPath(path, config), config)
   ).toThrowError('NavigationState not passed');
+});
+
+it('ignores initial prop if not the end of state object', () => {
+  const state = {
+    routes: [
+      {
+        name: 'Foo',
+        state: {
+          routes: [
+            {
+              name: 'Bar',
+              state: {
+                routes: [{ name: 'Baz' }],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  const config = {
+    Foo: {
+      path: 'foo/:id',
+      Foe: 'foe',
+      Bar: {
+        path: 'bar/:id',
+        parse: {
+          id: Number,
+        },
+        stringify: {
+          id: (id: number) => `id=${id}`,
+        },
+        initial: true,
+        Baz: {
+          path: 'baz',
+        },
+      },
+    },
+  };
+
+  const path = '/baz';
+
+  expect(getPathFromState(state, config)).toBe(path);
+  expect(getPathFromState(getStateFromPath(path, config), config)).toBe(path);
 });

--- a/packages/core/src/__tests__/getPathFromState.test.tsx
+++ b/packages/core/src/__tests__/getPathFromState.test.tsx
@@ -36,7 +36,7 @@ it('converts state to path string', () => {
 
 it('converts state to path string with config', () => {
   const path = '/few/bar/sweet/apple/baz/jane?id=x10&valid=true';
-  const config = {
+  const stateConfig = {
     Foo: 'few',
     Bar: 'bar/:type/:fruit',
     Baz: {
@@ -46,6 +46,14 @@ it('converts state to path string with config', () => {
         id: (id: string) => Number(id.replace(/^x/, '')),
         valid: Boolean,
       },
+    },
+  };
+
+  const pathConfig = {
+    Foo: 'few',
+    Bar: 'bar/:type/:fruit',
+    Baz: {
+      path: 'baz/:author',
       stringify: {
         author: (author: string) => author.toLowerCase(),
         id: (id: number) => `x${id}`,
@@ -79,8 +87,10 @@ it('converts state to path string with config', () => {
     ],
   };
 
-  expect(getPathFromState(state, config)).toBe(path);
-  expect(getPathFromState(getStateFromPath(path, config), config)).toBe(path);
+  expect(getPathFromState(state, pathConfig)).toBe(path);
+  expect(
+    getPathFromState(getStateFromPath(path, stateConfig), pathConfig)
+  ).toBe(path);
 });
 
 it('handles route without param', () => {
@@ -117,7 +127,7 @@ it("doesn't add query param for empty params", () => {
 
 it('handles state with config with nested screens', () => {
   const path = '/few/bar/sweet/apple/baz/jane?answer=42&count=10&valid=true';
-  const config = {
+  const stateConfig = {
     Foo: {
       Foe: 'few',
     },
@@ -129,6 +139,16 @@ it('handles state with config with nested screens', () => {
         count: Number,
         valid: Boolean,
       },
+    },
+  };
+
+  const pathConfig = {
+    Foo: {
+      Foe: 'few',
+    },
+    Bar: 'bar/:type/:fruit',
+    Baz: {
+      path: 'baz/:author',
       stringify: {
         author: (author: string) => author.toLowerCase(),
         id: (id: number) => `x${id}`,
@@ -173,13 +193,15 @@ it('handles state with config with nested screens', () => {
     ],
   };
 
-  expect(getPathFromState(state, config)).toBe(path);
-  expect(getPathFromState(getStateFromPath(path, config), config)).toBe(path);
+  expect(getPathFromState(state, pathConfig)).toBe(path);
+  expect(
+    getPathFromState(getStateFromPath(path, stateConfig), pathConfig)
+  ).toBe(path);
 });
 
 it('handles state with config with nested screens and unused configs', () => {
   const path = '/few/baz/jane?answer=42&count=10&valid=true';
-  const config = {
+  const stateConfig = {
     Foo: {
       Foe: 'few',
     },
@@ -190,6 +212,15 @@ it('handles state with config with nested screens and unused configs', () => {
         count: Number,
         valid: Boolean,
       },
+    },
+  };
+
+  const pathConfig = {
+    Foo: {
+      Foe: 'few',
+    },
+    Baz: {
+      path: 'baz/:author',
       stringify: {
         author: (author: string) => author.replace(/^\w/, c => c.toLowerCase()),
         unknown: (_: unknown) => 'x',
@@ -225,13 +256,28 @@ it('handles state with config with nested screens and unused configs', () => {
     ],
   };
 
-  expect(getPathFromState(state, config)).toBe(path);
-  expect(getPathFromState(getStateFromPath(path, config), config)).toBe(path);
+  expect(getPathFromState(state, pathConfig)).toBe(path);
+  expect(
+    getPathFromState(getStateFromPath(path, stateConfig), pathConfig)
+  ).toBe(path);
 });
 
 it('handles nested object with stringify in it', () => {
   const path = '/bar/sweet/apple/few/bis/jane?answer=42&count=10&valid=true';
-  const config = {
+  const stateConfig = {
+    Foo: {
+      Foe: 'few',
+    },
+    Bar: 'bar/:type/:fruit',
+    Baz: {
+      Bos: 'bos',
+      Bis: {
+        path: 'bis/:author',
+      },
+    },
+  };
+
+  const pathConfig = {
     Foo: {
       Foe: 'few',
     },
@@ -291,8 +337,10 @@ it('handles nested object with stringify in it', () => {
     ],
   };
 
-  expect(getPathFromState(state, config)).toBe(path);
-  expect(getPathFromState(getStateFromPath(path, config), config)).toBe(path);
+  expect(getPathFromState(state, pathConfig)).toBe(path);
+  expect(
+    getPathFromState(getStateFromPath(path, stateConfig), pathConfig)
+  ).toBe(path);
 });
 
 it('handles nested object for second route depth', () => {
@@ -326,12 +374,26 @@ it('handles nested object for second route depth', () => {
   };
 
   expect(getPathFromState(state, config)).toBe(path);
-  expect(getPathFromState(getStateFromPath(path), config)).toBe(path);
+  expect(getPathFromState(getStateFromPath(path, config), config)).toBe(path);
 });
 
 it('handles nested object for second route depth and and path and stringify in roots', () => {
   const path = '/baz';
-  const config = {
+  const stateConfig = {
+    Foo: {
+      path: 'foo/:id',
+      Foe: 'foe',
+      Bar: {
+        path: 'bar/:id',
+        parse: {
+          id: Number,
+        },
+        Baz: 'baz',
+      },
+    },
+  };
+
+  const pathConfig = {
     Foo: {
       path: 'foo/:id',
       stringify: {
@@ -342,9 +404,6 @@ it('handles nested object for second route depth and and path and stringify in r
         path: 'bar/:id',
         stringify: {
           id: (id: number) => `id=${id}`,
-        },
-        parse: {
-          id: Number,
         },
         Baz: 'baz',
       },
@@ -369,8 +428,10 @@ it('handles nested object for second route depth and and path and stringify in r
     ],
   };
 
-  expect(getPathFromState(state, config)).toBe(path);
-  expect(getPathFromState(getStateFromPath(path))).toBe(path);
+  expect(getPathFromState(state, pathConfig)).toBe(path);
+  expect(
+    getPathFromState(getStateFromPath(path, stateConfig), pathConfig)
+  ).toBe(path);
 });
 
 it('converts state with initial prop in config to empty path string', () => {
@@ -382,7 +443,25 @@ it('converts state with initial prop in config to empty path string', () => {
     ],
   };
 
-  const config = {
+  const stateConfig = {
+    Foo: {
+      path: 'foo/:id',
+      stringify: {
+        id: (id: number) => `id=${id}`,
+      },
+      initial: true,
+      Foe: 'foe',
+      Bar: {
+        path: 'bar/:id',
+        parse: {
+          id: Number,
+        },
+        Baz: 'baz',
+      },
+    },
+  };
+
+  const pathConfig = {
     Foo: {
       path: 'foo/:id',
       stringify: {
@@ -405,49 +484,103 @@ it('converts state with initial prop in config to empty path string', () => {
 
   const path = '';
 
-  expect(getPathFromState(state, config)).toBe(path);
-  expect(getPathFromState(getStateFromPath(path, config), config)).toBe(path);
+  expect(getPathFromState(state, pathConfig)).toBe(path);
+  expect(
+    getPathFromState(getStateFromPath(path, stateConfig), pathConfig)
+  ).toBe(path);
 });
 
-// it('converts state with initial prop in nested config to empty path string', () => {
-//   const state = {
-//     routes: [
-//       {
-//         name: 'Foo',
-//         state: {
-//           routes: [
-//             {
-//               name: 'Bar',
-//             },
-//           ],
-//         },
-//       },
-//     ],
-//   };
+it('converts state with initial prop in nested config to empty path string', () => {
+  const state = {
+    routes: [
+      {
+        name: 'Foo',
+        state: {
+          routes: [
+            {
+              name: 'Bar',
+              state: {
+                routes: [{ name: 'Baz' }],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  };
 
-//   const config = {
-//     Foo: {
-//       path: 'foo/:id',
-//       stringify: {
-//         id: (id: number) => `id=${id}`,
-//       },
-//       Foe: 'foe',
-//       Bar: {
-//         path: 'bar/:id',
-//         stringify: {
-//           id: (id: number) => `id=${id}`,
-//         },
-//         parse: {
-//           id: Number,
-//         },
-//         initial: true,
-//         Baz: 'baz',
-//       },
-//     },
-//   };
+  const stateConfig = {
+    Foo: {
+      path: 'foo/:id',
+      Foe: 'foe',
+      Bar: {
+        path: 'bar/:id',
+        parse: {
+          id: Number,
+        },
+        Baz: {
+          initial: true,
+        },
+      },
+    },
+  };
 
-//   const path = '';
+  const pathConfig = {
+    Foo: {
+      path: 'foo/:id',
+      stringify: {
+        id: (id: number) => `id=${id}`,
+      },
+      Foe: 'foe',
+      Bar: {
+        path: 'bar/:id',
+        stringify: {
+          id: (id: number) => `id=${id}`,
+        },
+        Baz: {
+          initial: true,
+        },
+      },
+    },
+  };
 
-//   expect(getPathFromState(state, config)).toBe(path);
-//   expect(getPathFromState(getStateFromPath(path, config))).toBe(path);
-// });
+  const path = '';
+
+  expect(getPathFromState(state, pathConfig)).toBe(path);
+  expect(
+    getPathFromState(getStateFromPath(path, stateConfig), pathConfig)
+  ).toBe(path);
+});
+
+it('throws if state is undefined', () => {
+  const config = {
+    Foo: {
+      path: 'foo/:id',
+      stringify: {
+        id: (id: number) => `id=${id}`,
+      },
+      Foe: 'foe',
+      Bar: {
+        path: 'bar/:id',
+        stringify: {
+          id: (id: number) => `id=${id}`,
+        },
+        parse: {
+          id: Number,
+        },
+        Baz: {
+          path: 'baz',
+        },
+      },
+    },
+  };
+
+  const path = '';
+
+  expect(() => getPathFromState(undefined, config)).toThrowError(
+    'NavigationState not passed'
+  );
+  expect(() =>
+    getPathFromState(getStateFromPath(path, config), config)
+  ).toThrowError('NavigationState not passed');
+});

--- a/packages/core/src/__tests__/getPathFromState.test.tsx
+++ b/packages/core/src/__tests__/getPathFromState.test.tsx
@@ -490,7 +490,7 @@ it('converts state with initial prop in config to empty path string', () => {
   ).toBe(path);
 });
 
-it('converts state with initial prop in nested config to empty path string', () => {
+it('converts state with initial prop in nested config to an empty path string', () => {
   const state = {
     routes: [
       {

--- a/packages/core/src/__tests__/getStateFromPath.test.tsx
+++ b/packages/core/src/__tests__/getStateFromPath.test.tsx
@@ -37,7 +37,7 @@ it('converts path string to initial state', () => {
 it('converts path string to initial state with config', () => {
   const path = '/few/bar/sweet/apple/baz/jane?count=10&answer=42&valid=true';
 
-  const stateConfig = {
+  const config = {
     Foo: 'few',
     Bar: 'bar/:type/:fruit',
     Baz: {
@@ -47,14 +47,6 @@ it('converts path string to initial state with config', () => {
         count: Number,
         valid: Boolean,
       },
-    },
-  };
-
-  const pathConfig = {
-    Foo: 'few',
-    Bar: 'bar/:type/:fruit',
-    Baz: {
-      path: 'baz/:author',
       stringify: {
         author: (author: string) => author.toLowerCase(),
       },
@@ -90,10 +82,10 @@ it('converts path string to initial state with config', () => {
     ],
   };
 
-  expect(getStateFromPath(path, stateConfig)).toEqual(state);
-  expect(
-    getStateFromPath(getPathFromState(state, pathConfig), stateConfig)
-  ).toEqual(state);
+  expect(getStateFromPath(path, config)).toEqual(state);
+  expect(getStateFromPath(getPathFromState(state, config), config)).toEqual(
+    state
+  );
 });
 
 it('handles leading slash when converting', () => {
@@ -152,7 +144,7 @@ it('handles route without param', () => {
 it('converts path string to initial state with config with nested screens', () => {
   const path = '/few/bar/sweet/apple/baz/jane?count=10&answer=42&valid=true';
 
-  const stateConfig = {
+  const config = {
     Foo: {
       Foe: 'few',
     },
@@ -164,16 +156,6 @@ it('converts path string to initial state with config with nested screens', () =
         count: Number,
         valid: Boolean,
       },
-    },
-  };
-
-  const pathConfig = {
-    Foo: {
-      Foe: 'few',
-    },
-    Bar: 'bar/:type/:fruit',
-    Baz: {
-      path: 'baz/:author',
       stringify: {
         author: (author: string) => author.toLowerCase(),
       },
@@ -216,16 +198,16 @@ it('converts path string to initial state with config with nested screens', () =
     ],
   };
 
-  expect(getStateFromPath(path, stateConfig)).toEqual(state);
-  expect(
-    getStateFromPath(getPathFromState(state, pathConfig), stateConfig)
-  ).toEqual(state);
+  expect(getStateFromPath(path, config)).toEqual(state);
+  expect(getStateFromPath(getPathFromState(state, config), config)).toEqual(
+    state
+  );
 });
 
 it('converts path string to initial state with config with nested screens and unused parse functions', () => {
   const path = '/few/baz/jane?count=10&answer=42&valid=true';
 
-  const stateConfig = {
+  const config = {
     Foo: {
       Foe: 'few',
     },
@@ -237,15 +219,6 @@ it('converts path string to initial state with config with nested screens and un
         valid: Boolean,
         id: Boolean,
       },
-    },
-  };
-
-  const pathConfig = {
-    Foo: {
-      Foe: 'few',
-    },
-    Baz: {
-      path: 'baz/:author',
     },
   };
 
@@ -277,16 +250,16 @@ it('converts path string to initial state with config with nested screens and un
     ],
   };
 
-  expect(getStateFromPath(path, stateConfig)).toEqual(state);
-  expect(
-    getStateFromPath(getPathFromState(state, pathConfig), stateConfig)
-  ).toEqual(state);
+  expect(getStateFromPath(path, config)).toEqual(state);
+  expect(getStateFromPath(getPathFromState(state, config), config)).toEqual(
+    state
+  );
 });
 
 it('handles nested object with unused configs and with parse in it', () => {
   const path = '/bar/sweet/apple/few/bis/jane?count=10&answer=42&valid=true';
 
-  const stateConfig = {
+  const config = {
     Foo: {
       Foe: 'few',
     },
@@ -301,19 +274,6 @@ it('handles nested object with unused configs and with parse in it', () => {
           count: Number,
           valid: Boolean,
         },
-      },
-    },
-  };
-
-  const pathConfig = {
-    Foo: {
-      Foe: 'few',
-    },
-    Bar: 'bar/:type/:fruit',
-    Baz: {
-      Bos: 'bos',
-      Bis: {
-        path: 'bis/:author',
       },
     },
   };
@@ -361,10 +321,10 @@ it('handles nested object with unused configs and with parse in it', () => {
     ],
   };
 
-  expect(getStateFromPath(path, stateConfig)).toEqual(state);
-  expect(
-    getStateFromPath(getPathFromState(state, pathConfig), stateConfig)
-  ).toEqual(state);
+  expect(getStateFromPath(path, config)).toEqual(state);
+  expect(getStateFromPath(getPathFromState(state, config), config)).toEqual(
+    state
+  );
 });
 
 it('handles parse in nested object for second route depth', () => {
@@ -407,11 +367,14 @@ it('handles parse in nested object for second route depth', () => {
 it('handles parse in nested object for second route depth and and path and parse in roots', () => {
   const path = '/baz';
 
-  const stateConfig = {
+  const config = {
     Foo: {
       path: 'foo/:id',
       parse: {
         id: Number,
+      },
+      stringify: {
+        id: (id: number) => `id=${id}`,
       },
       Foe: 'foe',
       Bar: {
@@ -419,20 +382,6 @@ it('handles parse in nested object for second route depth and and path and parse
         parse: {
           id: Number,
         },
-        Baz: 'baz',
-      },
-    },
-  };
-
-  const pathConfig = {
-    Foo: {
-      path: 'foo/:id',
-      stringify: {
-        id: (id: number) => `id=${id}`,
-      },
-      Foe: 'foe',
-      Bar: {
-        path: 'bar/:id',
         stringify: {
           id: (id: number) => `id=${id}`,
         },
@@ -459,40 +408,28 @@ it('handles parse in nested object for second route depth and and path and parse
     ],
   };
 
-  expect(getStateFromPath(path, stateConfig)).toEqual(state);
-  expect(
-    getStateFromPath(getPathFromState(state, pathConfig), stateConfig)
-  ).toEqual(state);
+  expect(getStateFromPath(path, config)).toEqual(state);
+  expect(getStateFromPath(getPathFromState(state, config), config)).toEqual(
+    state
+  );
 });
 
 it('converts empty path with initial prop in config to proper state', () => {
   const state = { routes: [{ name: 'Foo' }] };
 
-  const stateConfig = {
+  const config = {
     Foo: {
       path: 'foo/:id',
       initial: true,
+      stringify: {
+        id: (id: number) => `id=${id}`,
+      },
       Foe: 'foe',
       Bar: {
         path: 'bar/:id',
         parse: {
           id: Number,
         },
-        Baz: 'baz',
-      },
-    },
-  };
-
-  const pathConfig = {
-    Foo: {
-      path: 'foo/:id',
-      stringify: {
-        id: (id: number) => `id=${id}`,
-      },
-      initial: true,
-      Foe: 'foe',
-      Bar: {
-        path: 'bar/:id',
         stringify: {
           id: (id: number) => `id=${id}`,
         },
@@ -503,10 +440,10 @@ it('converts empty path with initial prop in config to proper state', () => {
 
   const path = '';
 
-  expect(getStateFromPath(path, stateConfig)).toEqual(state);
-  expect(
-    getStateFromPath(getPathFromState(state, pathConfig), stateConfig)
-  ).toEqual(state);
+  expect(getStateFromPath(path, config)).toEqual(state);
+  expect(getStateFromPath(getPathFromState(state, config), config)).toEqual(
+    state
+  );
 });
 
 it('converts empty path with initial prop in nested config to proper state', () => {
@@ -528,23 +465,7 @@ it('converts empty path with initial prop in nested config to proper state', () 
     ],
   };
 
-  const stateConfig = {
-    Foo: {
-      path: 'foo/:id',
-      Foe: 'foe',
-      Bar: {
-        path: 'bar/:id',
-        parse: {
-          id: Number,
-        },
-        Baz: {
-          initial: true,
-        },
-      },
-    },
-  };
-
-  const pathConfig = {
+  const config = {
     Foo: {
       path: 'foo/:id',
       stringify: {
@@ -553,6 +474,9 @@ it('converts empty path with initial prop in nested config to proper state', () 
       Foe: 'foe',
       Bar: {
         path: 'bar/:id',
+        parse: {
+          id: Number,
+        },
         stringify: {
           id: (id: number) => `id=${id}`,
         },
@@ -565,10 +489,10 @@ it('converts empty path with initial prop in nested config to proper state', () 
 
   const path = '';
 
-  expect(getStateFromPath(path, stateConfig)).toEqual(state);
-  expect(
-    getStateFromPath(getPathFromState(state, pathConfig), stateConfig)
-  ).toEqual(state);
+  expect(getStateFromPath(path, config)).toEqual(state);
+  expect(getStateFromPath(getPathFromState(state, config), config)).toEqual(
+    state
+  );
 });
 
 it('returns undefined if no initial prop and empty path', () => {
@@ -597,4 +521,54 @@ it('returns undefined if no initial prop and empty path', () => {
   const path = '';
 
   expect(getStateFromPath(path, config)).toEqual(undefined);
+});
+
+it('ignores initial prop if not the empty string', () => {
+  const state = {
+    routes: [
+      {
+        name: 'Foo',
+        state: {
+          routes: [
+            {
+              name: 'Bar',
+              state: {
+                routes: [{ name: 'Baz' }],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  const config = {
+    Foo: {
+      path: 'foo/:id',
+      stringify: {
+        id: (id: number) => `id=${id}`,
+      },
+      Foe: 'foe',
+      Bar: {
+        path: 'bar/:id',
+        parse: {
+          id: Number,
+        },
+        initial: true,
+        stringify: {
+          id: (id: number) => `id=${id}`,
+        },
+        Baz: {
+          path: 'baz',
+        },
+      },
+    },
+  };
+
+  const path = '/baz';
+
+  expect(getStateFromPath(path, config)).toEqual(state);
+  expect(getStateFromPath(getPathFromState(state, config), config)).toEqual(
+    state
+  );
 });

--- a/packages/core/src/__tests__/getStateFromPath.test.tsx
+++ b/packages/core/src/__tests__/getStateFromPath.test.tsx
@@ -36,7 +36,8 @@ it('converts path string to initial state', () => {
 
 it('converts path string to initial state with config', () => {
   const path = '/few/bar/sweet/apple/baz/jane?count=10&answer=42&valid=true';
-  const config = {
+
+  const stateConfig = {
     Foo: 'few',
     Bar: 'bar/:type/:fruit',
     Baz: {
@@ -46,6 +47,14 @@ it('converts path string to initial state with config', () => {
         count: Number,
         valid: Boolean,
       },
+    },
+  };
+
+  const pathConfig = {
+    Foo: 'few',
+    Bar: 'bar/:type/:fruit',
+    Baz: {
+      path: 'baz/:author',
       stringify: {
         author: (author: string) => author.toLowerCase(),
       },
@@ -81,10 +90,10 @@ it('converts path string to initial state with config', () => {
     ],
   };
 
-  expect(getStateFromPath(path, config)).toEqual(state);
-  expect(getStateFromPath(getPathFromState(state, config), config)).toEqual(
-    state
-  );
+  expect(getStateFromPath(path, stateConfig)).toEqual(state);
+  expect(
+    getStateFromPath(getPathFromState(state, pathConfig), stateConfig)
+  ).toEqual(state);
 });
 
 it('handles leading slash when converting', () => {
@@ -142,7 +151,8 @@ it('handles route without param', () => {
 
 it('converts path string to initial state with config with nested screens', () => {
   const path = '/few/bar/sweet/apple/baz/jane?count=10&answer=42&valid=true';
-  const config = {
+
+  const stateConfig = {
     Foo: {
       Foe: 'few',
     },
@@ -154,6 +164,16 @@ it('converts path string to initial state with config with nested screens', () =
         count: Number,
         valid: Boolean,
       },
+    },
+  };
+
+  const pathConfig = {
+    Foo: {
+      Foe: 'few',
+    },
+    Bar: 'bar/:type/:fruit',
+    Baz: {
+      path: 'baz/:author',
       stringify: {
         author: (author: string) => author.toLowerCase(),
       },
@@ -196,15 +216,16 @@ it('converts path string to initial state with config with nested screens', () =
     ],
   };
 
-  expect(getStateFromPath(path, config)).toEqual(state);
-  expect(getStateFromPath(getPathFromState(state, config), config)).toEqual(
-    state
-  );
+  expect(getStateFromPath(path, stateConfig)).toEqual(state);
+  expect(
+    getStateFromPath(getPathFromState(state, pathConfig), stateConfig)
+  ).toEqual(state);
 });
 
 it('converts path string to initial state with config with nested screens and unused parse functions', () => {
   const path = '/few/baz/jane?count=10&answer=42&valid=true';
-  const config = {
+
+  const stateConfig = {
     Foo: {
       Foe: 'few',
     },
@@ -216,6 +237,15 @@ it('converts path string to initial state with config with nested screens and un
         valid: Boolean,
         id: Boolean,
       },
+    },
+  };
+
+  const pathConfig = {
+    Foo: {
+      Foe: 'few',
+    },
+    Baz: {
+      path: 'baz/:author',
     },
   };
 
@@ -247,15 +277,16 @@ it('converts path string to initial state with config with nested screens and un
     ],
   };
 
-  expect(getStateFromPath(path, config)).toEqual(state);
-  expect(getStateFromPath(getPathFromState(state, config), config)).toEqual(
-    state
-  );
+  expect(getStateFromPath(path, stateConfig)).toEqual(state);
+  expect(
+    getStateFromPath(getPathFromState(state, pathConfig), stateConfig)
+  ).toEqual(state);
 });
 
 it('handles nested object with unused configs and with parse in it', () => {
   const path = '/bar/sweet/apple/few/bis/jane?count=10&answer=42&valid=true';
-  const config = {
+
+  const stateConfig = {
     Foo: {
       Foe: 'few',
     },
@@ -270,6 +301,19 @@ it('handles nested object with unused configs and with parse in it', () => {
           count: Number,
           valid: Boolean,
         },
+      },
+    },
+  };
+
+  const pathConfig = {
+    Foo: {
+      Foe: 'few',
+    },
+    Bar: 'bar/:type/:fruit',
+    Baz: {
+      Bos: 'bos',
+      Bis: {
+        path: 'bis/:author',
       },
     },
   };
@@ -317,14 +361,15 @@ it('handles nested object with unused configs and with parse in it', () => {
     ],
   };
 
-  expect(getStateFromPath(path, config)).toEqual(state);
-  expect(getStateFromPath(getPathFromState(state, config), config)).toEqual(
-    state
-  );
+  expect(getStateFromPath(path, stateConfig)).toEqual(state);
+  expect(
+    getStateFromPath(getPathFromState(state, pathConfig), stateConfig)
+  ).toEqual(state);
 });
 
 it('handles parse in nested object for second route depth', () => {
   const path = '/baz';
+
   const config = {
     Foo: {
       path: 'foo',
@@ -361,14 +406,12 @@ it('handles parse in nested object for second route depth', () => {
 
 it('handles parse in nested object for second route depth and and path and parse in roots', () => {
   const path = '/baz';
-  const config = {
+
+  const stateConfig = {
     Foo: {
       path: 'foo/:id',
       parse: {
         id: Number,
-      },
-      stringify: {
-        id: (id: number) => `id=${id}`,
       },
       Foe: 'foe',
       Bar: {
@@ -376,6 +419,20 @@ it('handles parse in nested object for second route depth and and path and parse
         parse: {
           id: Number,
         },
+        Baz: 'baz',
+      },
+    },
+  };
+
+  const pathConfig = {
+    Foo: {
+      path: 'foo/:id',
+      stringify: {
+        id: (id: number) => `id=${id}`,
+      },
+      Foe: 'foe',
+      Bar: {
+        path: 'bar/:id',
         stringify: {
           id: (id: number) => `id=${id}`,
         },
@@ -402,8 +459,142 @@ it('handles parse in nested object for second route depth and and path and parse
     ],
   };
 
-  expect(getStateFromPath(path, config)).toEqual(state);
-  expect(getStateFromPath(getPathFromState(state, config), config)).toEqual(
-    state
-  );
+  expect(getStateFromPath(path, stateConfig)).toEqual(state);
+  expect(
+    getStateFromPath(getPathFromState(state, pathConfig), stateConfig)
+  ).toEqual(state);
+});
+
+it('converts empty path with initial prop in config to proper state', () => {
+  const state = { routes: [{ name: 'Foo' }] };
+
+  const stateConfig = {
+    Foo: {
+      path: 'foo/:id',
+      initial: true,
+      Foe: 'foe',
+      Bar: {
+        path: 'bar/:id',
+        parse: {
+          id: Number,
+        },
+        Baz: 'baz',
+      },
+    },
+  };
+
+  const pathConfig = {
+    Foo: {
+      path: 'foo/:id',
+      stringify: {
+        id: (id: number) => `id=${id}`,
+      },
+      initial: true,
+      Foe: 'foe',
+      Bar: {
+        path: 'bar/:id',
+        stringify: {
+          id: (id: number) => `id=${id}`,
+        },
+        Baz: 'baz',
+      },
+    },
+  };
+
+  const path = '';
+
+  expect(getStateFromPath(path, stateConfig)).toEqual(state);
+  expect(
+    getStateFromPath(getPathFromState(state, pathConfig), stateConfig)
+  ).toEqual(state);
+});
+
+it('converts empty path with initial prop in nested config to proper state', () => {
+  const state = {
+    routes: [
+      {
+        name: 'Foo',
+        state: {
+          routes: [
+            {
+              name: 'Bar',
+              state: {
+                routes: [{ name: 'Baz' }],
+              },
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  const stateConfig = {
+    Foo: {
+      path: 'foo/:id',
+      Foe: 'foe',
+      Bar: {
+        path: 'bar/:id',
+        parse: {
+          id: Number,
+        },
+        Baz: {
+          initial: true,
+        },
+      },
+    },
+  };
+
+  const pathConfig = {
+    Foo: {
+      path: 'foo/:id',
+      stringify: {
+        id: (id: number) => `id=${id}`,
+      },
+      Foe: 'foe',
+      Bar: {
+        path: 'bar/:id',
+        stringify: {
+          id: (id: number) => `id=${id}`,
+        },
+        Baz: {
+          initial: true,
+        },
+      },
+    },
+  };
+
+  const path = '';
+
+  expect(getStateFromPath(path, stateConfig)).toEqual(state);
+  expect(
+    getStateFromPath(getPathFromState(state, pathConfig), stateConfig)
+  ).toEqual(state);
+});
+
+it('returns undefined if no initial prop and empty path', () => {
+  const config = {
+    Foo: {
+      path: 'foo/:id',
+      stringify: {
+        id: (id: number) => `id=${id}`,
+      },
+      Foe: 'foe',
+      Bar: {
+        path: 'bar/:id',
+        stringify: {
+          id: (id: number) => `id=${id}`,
+        },
+        parse: {
+          id: Number,
+        },
+        Baz: {
+          path: 'baz',
+        },
+      },
+    },
+  };
+
+  const path = '';
+
+  expect(getStateFromPath(path, config)).toEqual(undefined);
 });

--- a/packages/core/src/getPathFromState.tsx
+++ b/packages/core/src/getPathFromState.tsx
@@ -64,8 +64,11 @@ export default function getPathFromState(
         pattern = currentOptions[route.name] as string;
         break;
       } else if (typeof currentOptions[route.name] === 'object') {
-        // if there is `initial` prop in the config, we should return an empty string immediately
-        if ((currentOptions[route.name] as { initial?: boolean }).initial) {
+        // if there is `initial` prop in the config and it is the of the state object, we should return an empty string immediately
+        if (
+          (currentOptions[route.name] as { initial?: boolean }).initial &&
+          route.state === undefined
+        ) {
           return '';
         }
         if (route.state === undefined) {
@@ -81,11 +84,9 @@ export default function getPathFromState(
       }
     }
 
-    const config =
-      currentOptions[route.name] !== undefined
-        ? (currentOptions[route.name] as { stringify?: StringifyConfig })
-            .stringify
-        : undefined;
+    const config = (currentOptions[route.name] as {
+      stringify?: StringifyConfig;
+    })?.stringify;
 
     const params = route.params
       ? // Stringify all of the param values before we use them

--- a/packages/core/src/getPathFromState.tsx
+++ b/packages/core/src/getPathFromState.tsx
@@ -8,7 +8,7 @@ type StringifyConfig = Record<string, (value: any) => string>;
 type Options = {
   [routeName: string]:
     | string
-    | { path: string; stringify?: StringifyConfig }
+    | { path: string; stringify?: StringifyConfig; initial?: boolean }
     | Options;
 };
 
@@ -60,6 +60,10 @@ export default function getPathFromState(
         pattern = currentOptions[route.name] as string;
         break;
       } else if (typeof currentOptions[route.name] === 'object') {
+        // if there is `initial` property, we should return empty string immidiately
+        if ((currentOptions[route.name] as { initial?: boolean }).initial) {
+          return '';
+        }
         if (route.state === undefined) {
           pattern = (currentOptions[route.name] as { path: string }).path;
           break;

--- a/packages/core/src/getPathFromState.tsx
+++ b/packages/core/src/getPathFromState.tsx
@@ -43,6 +43,10 @@ export default function getPathFromState(
   state?: State,
   options: Options = {}
 ): string {
+  if (state === undefined) {
+    throw Error('NavigationState not passed');
+  }
+
   let path = '/';
 
   let current: State | undefined = state;
@@ -50,7 +54,7 @@ export default function getPathFromState(
   while (current) {
     let index = typeof current.index === 'number' ? current.index : 0;
     let route = current.routes[index] as Route<string> & {
-      state?: State | undefined;
+      state?: State;
     };
     let currentOptions = options;
     let pattern = route.name;
@@ -60,7 +64,7 @@ export default function getPathFromState(
         pattern = currentOptions[route.name] as string;
         break;
       } else if (typeof currentOptions[route.name] === 'object') {
-        // if there is `initial` property, we should return empty string immidiately
+        // if there is `initial` prop in config, we should return empty string immidiately
         if ((currentOptions[route.name] as { initial?: boolean }).initial) {
           return '';
         }
@@ -71,7 +75,7 @@ export default function getPathFromState(
           currentOptions = currentOptions[route.name] as Options;
           index = typeof route.state.index === 'number' ? route.state.index : 0;
           route = route.state.routes[index] as Route<string> & {
-            state?: State | undefined;
+            state?: State;
           };
         }
       }

--- a/packages/core/src/getPathFromState.tsx
+++ b/packages/core/src/getPathFromState.tsx
@@ -64,7 +64,7 @@ export default function getPathFromState(
         pattern = currentOptions[route.name] as string;
         break;
       } else if (typeof currentOptions[route.name] === 'object') {
-        // if there is `initial` prop in config, we should return empty string immidiately
+        // if there is `initial` prop in the config, we should return an empty string immediately
         if ((currentOptions[route.name] as { initial?: boolean }).initial) {
           return '';
         }

--- a/packages/core/src/getStateFromPath.tsx
+++ b/packages/core/src/getStateFromPath.tsx
@@ -229,11 +229,16 @@ function createNormalizedConfigs(
             value.parse ? (value.parse as ParseConfig) : undefined
           )
         );
-      } else if (nestedKey === 'parse' || nestedKey === 'initial') {
+      } else if (
+        nestedKey === 'parse' ||
+        nestedKey === 'initial' ||
+        nestedKey === 'stringify'
+      ) {
         // We handle custom parse function when a `path` is specified (in nestedKey === path)
         // `initial` prop should be ignored if the path is not an empty string
+        // `stringify` prop should be ignored because it belongs to getPathFromState parsing
       } else {
-        // If the name of the key is not `path` or `parse` or `initial`, it's a nested config for the route
+        // If the name of the key is not `path`, `parse`, `stringify` or `initial`, it's a nested config for the route
         // So we need to traverse into it and collect the configs
         const result = createNormalizedConfigs(
           nestedKey,

--- a/packages/core/src/getStateFromPath.tsx
+++ b/packages/core/src/getStateFromPath.tsx
@@ -231,9 +231,9 @@ function createNormalizedConfigs(
         );
       } else if (nestedKey === 'parse' || nestedKey === 'initial') {
         // We handle custom parse function when a `path` is specified (in nestedKey === path)
-        // `initial` prop should be ignored if path is not empty string
+        // `initial` prop should be ignored if the path is not an empty string
       } else {
-        // If the name of the key is not `path` or `parse` or `initial`, it's a nested config for route
+        // If the name of the key is not `path` or `parse` or `initial`, it's a nested config for the route
         // So we need to traverse into it and collect the configs
         const result = createNormalizedConfigs(
           nestedKey,


### PR DESCRIPTION
Added parsing empty string in deep linking. It is made by adding the `initial` property to the config route, which is the initial route for the app. In getPathFromState, if `initial` property occurs in the config, an empty string is returned immediately. In getStateFromPath, if the given path is an empty string, we look for `initial` property in the config and return state object referring to the given config.